### PR TITLE
[FEAT] implement hard filter from trigger & forecast data - pit 108

### DIFF
--- a/src/app/core/settings.py
+++ b/src/app/core/settings.py
@@ -1,0 +1,11 @@
+# src/app/core/settings.py
+from __future__ import annotations
+import os
+
+WEATHER_TZ = os.getenv("WEATHER_TZ", "Asia/Seoul")
+
+TEMP_HOT_C = float(os.getenv("RECO_TEMP_HOT_C", "30"))
+TEMP_COLD_C = float(os.getenv("RECO_TEMP_COLD_C", "0"))
+HUMIDITY_HIGH = int(os.getenv("RECO_HUMIDITY_HIGH", "85"))
+
+OPENWEATHER_API_KEY = os.getenv("OPENWEATHER_API_KEY", "")

--- a/src/app/core/urls.py
+++ b/src/app/core/urls.py
@@ -1,0 +1,30 @@
+# src/app/core/urls.py
+from __future__ import annotations
+import os
+from typing import Final
+
+# 베이스 도메인은 .env로 덮어쓸 수 있게
+OPENWEATHER_BASE: Final[str] = os.getenv("OPENWEATHER_BASE", "https://api.openweathermap.org")
+OPENWEATHER_PRO_BASE: Final[str] = os.getenv("OPENWEATHER_PRO_BASE", "https://pro.openweathermap.org")
+
+# 경로 상수 (도메인과 분리)
+OPENWEATHER_PATHS = {
+    # 무료 5일/3시간 예보
+    "forecast3h": "/data/2.5/forecast",
+    # 현재 날씨
+    "current": "/data/2.5/weather",
+    # One Call 3.0 (48h hourly) - 과금 유의
+    "onecall": "/data/3.0/onecall",
+    # Hourly 4 days (Pro 도메인) - 학생/유료
+    "forecast_hourly_4d": "/data/2.5/forecast/hourly",
+}
+
+def ow_url(path_key: str, *, pro: bool = False) -> str:
+    """
+    OpenWeather endpoint 빌더.
+    ex) ow_url("forecast3h") -> "https://api.openweathermap.org/data/2.5/forecast"
+        ow_url("forecast_hourly_4d", pro=True) -> "https://pro.openweathermap.org/data/2.5/forecast/hourly"
+    """
+    base = OPENWEATHER_PRO_BASE if pro else OPENWEATHER_BASE
+    path = OPENWEATHER_PATHS[path_key]
+    return f"{base}{path}"

--- a/src/app/filters/categories.py
+++ b/src/app/filters/categories.py
@@ -1,0 +1,13 @@
+# src/app/filters/categories.py
+ALL_CATEGORIES = [
+    "restaurant","cafe","bar",
+    "activity","attraction","exhibit",
+    "walk","view","nature",
+    "shopping","performance",
+]
+
+INDOOR_STRICT = {"restaurant","cafe","bar","shopping","performance"}
+OUTDOOR_STRICT = {"walk","nature"}
+MIXED = {"view","attraction","activity","exhibit"}
+
+assert set(ALL_CATEGORIES) == INDOOR_STRICT | OUTDOOR_STRICT | MIXED

--- a/src/app/filters/hardfilter.py
+++ b/src/app/filters/hardfilter.py
@@ -1,0 +1,53 @@
+# src/app/filters/hardfilter.py
+from __future__ import annotations
+from typing import Dict, List, Set
+from app.core.settings import WEATHER_TZ, TEMP_HOT_C, TEMP_COLD_C, HUMIDITY_HIGH
+from app.utils.timewindow import window_now_to_end_local_strict
+from app.models.schemas import Trigger
+from app.filters.categories import ALL_CATEGORIES, OUTDOOR_STRICT
+from app.weather.types import ForecastProvider
+
+async def run_category_hard_filter(*, trigger: Trigger, weather_provider: ForecastProvider) -> Dict[str, object]:
+    allowed: Set[str] = set(ALL_CATEGORIES)
+    reasons: Dict[str, List[str]] = {c: [] for c in ALL_CATEGORIES}
+
+    # 시간창 계산 (now→end, strict)
+    start_utc, end_utc = window_now_to_end_local_strict(trigger.time_window[1], tz=WEATHER_TZ)
+
+    # 예보 요약
+    lat = trigger.start[1]; lon = trigger.start[0]
+    summary = await weather_provider.window_summary(lat=lat, lon=lon, start_dt=start_utc, end_dt=end_utc)
+
+    # 규칙: 창구간 내 ANY면 실외 제외
+    weather_map = {
+    "raining_any": "weather:rain(window)",
+    "hot_any": "weather:hot(window)",
+    "cold_any": "weather:cold(window)",
+    "humid_any": "weather:humid(window)",
+    }
+
+    for attr, reason in weather_map.items():
+        if getattr(summary, attr):
+            for c in OUTDOOR_STRICT & allowed:
+                allowed.discard(c)
+                reasons[c].append(reason)
+                
+    # 술 의향
+    if not trigger.drink_intent and "bar" in allowed:
+        allowed.discard("bar"); reasons["bar"].append("drink_intent:false")
+
+    excluded = {c: rs for c, rs in reasons.items() if rs}
+    return {
+        "allowed_categories": sorted(allowed),
+        "excluded_categories": excluded,
+        "hardfilter_debug": {
+            "window_utc": [start_utc.isoformat(), end_utc.isoformat()],
+            "summary_flags": {
+                "raining": summary.raining_any, "hot": summary.hot_any,
+                "cold": summary.cold_any, "humid": summary.humid_any
+            },
+            "max_temp": summary.max_temp, "min_temp": summary.min_temp, "max_humidity": summary.max_humidity,
+            "time_window_input": trigger.time_window, "drink_intent": trigger.drink_intent,
+            "thresholds": {"TEMP_HOT_C": TEMP_HOT_C, "TEMP_COLD_C": TEMP_COLD_C, "HUMIDITY_HIGH": HUMIDITY_HIGH},
+        },
+    }

--- a/src/app/models/schemas.py
+++ b/src/app/models/schemas.py
@@ -1,0 +1,26 @@
+# src/app/models/schemas.py
+from typing import Tuple, List, Dict, Optional
+from pydantic import BaseModel, Field, root_validator
+
+# ===== Request =====
+class Trigger(BaseModel):
+    start: Tuple[float, float] = Field(..., description="[lng, lat]")  #  처음 시작위치
+    time_window: Tuple[str, str] = Field(..., description='["HH:MM","HH:MM"]')# 처음 시작 시간 ~ 데이트 종료 시간
+    mode: Optional[str] = Field("walk", description='"walk" | "public"') # 뚜벅이냐 or 차가있냐
+    drink_intent: bool = Field(..., description="오늘 술 의향") 
+    
+    @root_validator
+    def _validate_time(cls, v):
+        for hm in v["time_window"]:
+            h, m = hm.split(":")
+            int(h); int(m)
+        return v
+
+class RecommendRequest(BaseModel):
+    trigger: Trigger
+
+# ===== Response =====
+class FilterResult(BaseModel):
+    allowed: List[str]
+    excluded: Dict[str, List[str]]
+    debug: Dict[str, object]

--- a/src/app/models/schemas.py
+++ b/src/app/models/schemas.py
@@ -1,20 +1,73 @@
 # src/app/models/schemas.py
 from typing import Tuple, List, Dict, Optional
-from pydantic import BaseModel, Field, root_validator
+from pydantic import BaseModel, Field, model_validator
 
 # ===== Request =====
 class Trigger(BaseModel):
-    start: Tuple[float, float] = Field(..., description="[lng, lat]")  #  처음 시작위치
-    time_window: Tuple[str, str] = Field(..., description='["HH:MM","HH:MM"]')# 처음 시작 시간 ~ 데이트 종료 시간
-    mode: Optional[str] = Field("walk", description='"walk" | "public"') # 뚜벅이냐 or 차가있냐
-    drink_intent: bool = Field(..., description="오늘 술 의향") 
-    
-    @root_validator
-    def _validate_time(cls, v):
-        for hm in v["time_window"]:
+    start: Tuple[float, float] = Field(..., description="[lng, lat]")
+    time_window: Tuple[str, str] = Field(..., description='["HH:MM","HH:MM"]')
+    mode: Optional[str] = Field("walk", description='"walk" | "public"')
+    drink_intent: bool = Field(..., description="오늘 술 의향")
+
+    @model_validator(mode="after")
+    def _validate_time(self):
+        for hm in self.time_window:
             h, m = hm.split(":")
             int(h); int(m)
-        return v
+        return self
+
+from typing import TypedDict, List, Any, Optional
+
+# 수정된 POI 데이터 구조 (제공된 테이블 스키마에 맞춤)
+class POIData(TypedDict):
+    id: str # 'id'는 string 또는 int가 될 수 있지만, 일반적으로 uuid를 사용하므로 string으로 가정
+    updated_at: str # 'updated_at'은 datetime이므로 string으로 처리
+    name: str # '장소명'
+    category: str # '장소타입'
+    lat: float # '위도'
+    lng: float # '경도'
+    indoor: bool # '실내외'
+    price_level: int # '가격대'
+    open_hours: Any # '요일별 영업시간'은 복잡한 객체일 수 있으므로 Any로 처리
+    alcohol: int # '음주 정도'
+    mood_tag: str # '무드 태그'는 string 또는 List[str]일 수 있으므로 string으로 처리
+    food_tag: List[str] # '음식 태그'는 string 배열이므로 List[str]
+    rating_avg: float # '평점 평균'
+    created_at: str # '생성일'은 datetime이므로 string으로 처리
+    link: str # '링크'
+    
+# 수정된 사용자 데이터 구조 \
+class UserData(TypedDict):
+    id: str # 'id'는 string 또는 int가 될 수 있지만, 일반적으로 string으로 가정
+    name: str # '이름'
+    birthday: str # '생년월일'은 date이므로 string으로 처리
+    gender: str # '성별'은 enum이므로 string으로 처리
+    like_alcohol: bool # '술 좋아하는지 여부'
+    active: bool # '활동적'
+    food_preference: str # '좋아하는 음식' 
+    date_cost: int # '평소 데이트 비용' 
+    preferred_atmosphere: str # '선호 분위기'
+    uuid: str # '사용자 매칭용 UUID'는 long이므로 string으로 처리
+    status: str # '계정 활성화 여부'는 enum이므로 string으로 처리
+    created_at: str # '생성일'은 datetime이므로 string으로 처리
+    updated_at: str # '수정일'은 datetime이므로 string으로 처리
+    reroll: int # '재추천 횟수'는 long이므로 int로 처리
+
+# LangGraph의 상태를 정의하는 메인 스키마
+class State(TypedDict):
+    """LangGraph의 상태를 나타내는 TypedDict."""
+    query: str # 사용자의 초기 요청 (예: "강남에서 데이트 코스 추천해줘")
+    user_data: Dict[str, Any] # 사용자의 유저 데이터 (온보딩 및 기존 데이터)
+    trigger_data: Dict[str, Any] # 날씨, 음주 등 트리거 데이터
+    poi_data: Optional[Dict[str, List[POIData]]] # Google Place API에서 수집한 정제된 POI 데이터
+    available_categories: List[str] # 하드 필터링 후 남은 카테고리
+    recommended_sequence: List[str] # LLM이 추천한 카테고리 시퀀스 (예: "식당", "카페")
+    recommendations: List[Dict[str, Any]] # 각 카테고리 에이전트의 추천 결과
+    current_judge: Optional[bool] # 검증 LLM의 판단 결과
+    judgement_reason: Optional[str] # 검증 LLM의 판단 이유
+    final_output: Optional[str] # 최종 JSON 형식의 출력
+    check_count: int # 재시도 횟수 (선택적)
+
 
 class RecommendRequest(BaseModel):
     trigger: Trigger

--- a/src/app/nodes/filters.py
+++ b/src/app/nodes/filters.py
@@ -1,0 +1,215 @@
+# src/app/nodes/filters.py
+from __future__ import annotations
+import os
+from dataclasses import dataclass
+from datetime import time, datetime, timedelta
+from typing import List, Dict, Tuple, Set, Protocol, Optional
+
+import httpx
+from zoneinfo import ZoneInfo
+
+from app.models.schemas import Trigger
+
+# ---------- 카테고리 정의 ----------
+ALL_CATEGORIES: List[str] = [
+    "restaurant", "cafe", "bar",
+    "activity", "attraction", "exhibit",
+    "walk", "view", "nature",
+    "shopping", "performance",
+]
+
+INDOOR_STRICT: Set[str] = {"restaurant", "cafe", "bar", "activity", "exhibit", "shopping", "performance"}
+OUTDOOR_STRICT: Set[str] = {"walk", "nature"}
+MIXED: Set[str] = {"view", "attraction"}
+assert set(ALL_CATEGORIES) == INDOOR_STRICT | OUTDOOR_STRICT | MIXED
+
+# ---------- 임계값 (env로 조정 가능) ----------
+TEMP_HOT_C = float(os.getenv("RECO_TEMP_HOT_C", "30"))     # ≥ 덥다 → 확정 야외 제외
+TEMP_COLD_C = float(os.getenv("RECO_TEMP_COLD_C", "0"))    # ≤ 춥다 → 확정 야외 제외
+HUMIDITY_HIGH = int(os.getenv("RECO_HUMIDITY_HIGH", "85")) # ≥ 매우 습함 → 확정 야외 제외
+LOCAL_TZ = os.getenv("WEATHER_TZ", "Asia/Seoul")           # time_window 해석 타임존
+
+# ---------- 유틸 ----------
+def _parse_hm(hm: str) -> Tuple[int, int]:
+    h, m = hm.split(":")
+    return int(h), int(m)
+
+def window_now_to_end_local_strict(
+    end_hm: str,
+    tz: str = LOCAL_TZ,
+) -> tuple[datetime, datetime]:
+    """
+    로컬 타임존 기준:
+    - 시작: 지금(now)
+    - 종료: 사용자가 설정한 종료 시각(HH:MM)
+    - 종료가 지금보다 이르면 에러
+    - 최소 길이/자정 넘김 이월 등 '자동 보정' 없음 (엄격)
+    """
+    now_local = datetime.now(ZoneInfo(tz))
+    eh, em = _parse_hm(end_hm)
+    end_local = now_local.replace(hour=eh, minute=em, second=0, microsecond=0)
+
+    if end_local <= now_local:
+        raise ValueError(
+            f"end time must be later than now; now={now_local.strftime('%H:%M')}, end={end_hm}"
+        )
+
+    # UTC로 변환해서 반환
+    return now_local.astimezone(ZoneInfo("UTC")), end_local.astimezone(ZoneInfo("UTC"))
+
+# ---------- 예보 집계 DTO ----------
+@dataclass
+class WindowSummary:
+    raining_any: bool
+    hot_any: bool
+    cold_any: bool
+    humid_any: bool
+    samples: int
+    max_temp: Optional[float]
+    min_temp: Optional[float]
+    max_humidity: Optional[int]
+
+# ---------- Provider 프로토콜 ----------
+class ForecastProvider(Protocol):
+    async def window_summary(self, *, lat: float, lon: float, start_dt: datetime, end_dt: datetime) -> WindowSummary: ...
+
+# ---------- 무료 3시간 예보 Provider (/data/2.5/forecast) ----------
+class Free3hForecastProvider:
+    """
+    5일/3시간 예보(무료)를 사용.
+    도메인: https://api.openweathermap.org
+    엔드포인트: /data/2.5/forecast
+    """
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        self.api_key = api_key or os.getenv("OPENWEATHER_API_KEY") or ""
+        if not self.api_key:
+            raise RuntimeError("OPENWEATHER_API_KEY missing")
+
+    async def _get(self, *, lat: float, lon: float) -> List[dict]:
+        url = "https://api.openweathermap.org/data/2.5/forecast"
+        params = {"lat": lat, "lon": lon, "appid": self.api_key, "units": "metric"}
+        async with httpx.AsyncClient(timeout=6.0) as client:
+            r = await client.get(url, params=params)
+            r.raise_for_status()
+        data = r.json()
+        return data.get("list", [])  # 각 item: {dt, main:{temp,humidity}, weather:[{main}], rain:{'3h':..}}
+
+    async def window_summary(self, *, lat: float, lon: float, start_dt: datetime, end_dt: datetime) -> WindowSummary:
+        items = await self._get(lat=lat, lon=lon)
+
+        sel: List[dict] = []
+        for it in items:
+            # API의 dt는 UTC epoch(sec)
+            t = datetime.utcfromtimestamp(int(it["dt"])).replace(tzinfo=ZoneInfo("UTC"))
+            # 3시간 슬롯의 중심 시각으로 간주하고, 중심이 창구간에 걸리면 포함(간단 정책)
+            if start_dt <= t <= end_dt:
+                sel.append(it)
+
+        if not sel:
+            return WindowSummary(False, False, False, False, 0, None, None, None)
+
+        def is_rain(it: dict) -> bool:
+            wmain = ((it.get("weather") or [{}])[0].get("main") or "").lower()
+            rain3h = (it.get("rain") or {}).get("3h", 0) or 0
+            return ("rain" in wmain) or ("drizzle" in wmain) or (rain3h > 0)
+
+        temps = [float(it["main"]["temp"]) for it in sel if "main" in it and "temp" in it["main"]]
+        hums  = [int(it["main"]["humidity"]) for it in sel if "main" in it and "humidity" in it["main"]]
+
+        return WindowSummary(
+            raining_any = any(is_rain(it) for it in sel),
+            hot_any     = any(t >= TEMP_HOT_C for t in temps) if temps else False,
+            cold_any    = any(t <= TEMP_COLD_C for t in temps) if temps else False,
+            humid_any   = any(h >= HUMIDITY_HIGH for h in hums) if hums else False,
+            samples     = len(sel),
+            max_temp    = max(temps) if temps else None,
+            min_temp    = min(temps) if temps else None,
+            max_humidity= max(hums)  if hums  else None,
+        )
+
+# ---------- 하드필터 코어 (LLM/그래프에 넘길 데이터만 산출) ----------
+async def run_category_hard_filter(
+    *,
+    trigger: Trigger,
+    weather_provider: ForecastProvider,
+) -> Dict[str, object]:
+    """
+    반환(프론트 X): LLM/후속 노드 입력용 페이로드
+    {
+      "allowed_categories": [...],
+      "excluded_categories": {cat: [reasons...]},
+      "hardfilter_debug": {...}
+    }
+    """
+    allowed = set(ALL_CATEGORIES)
+    reasons: Dict[str, List[str]] = {c: [] for c in ALL_CATEGORIES}
+
+    # 0) '지금 -> 종료시각' 창구간(로컬 → UTC, 종료가 지금보다 이르면 예외)
+    lng, lat = trigger.start
+    
+    # trigger.time_window = (start_hm, end_hm) 라면, end만 사용
+    end_hm = trigger.time_window[1]
+    start_utc, end_utc = window_now_to_end_local_strict(end_hm, tz=LOCAL_TZ)
+
+    # 1) 예보 집계(창구간과 겹치는 3시간 슬롯 ANY)
+    summary = await weather_provider.window_summary(lat=lat, lon=lng, start_dt=start_utc, end_dt=end_utc)
+
+    # 2) 날씨 규칙
+    if summary.raining_any:
+        for c in OUTDOOR_STRICT & allowed:
+            allowed.discard(c)
+            reasons[c].append("weather:rain(window)")
+
+    if summary.hot_any:
+        for c in OUTDOOR_STRICT & allowed:
+            allowed.discard(c)
+            reasons[c].append("weather:hot(window)")
+
+    if summary.cold_any:
+        for c in OUTDOOR_STRICT & allowed:
+            allowed.discard(c)
+            reasons[c].append("weather:cold(window)")
+
+    if summary.humid_any:
+        for c in OUTDOOR_STRICT & allowed:
+            allowed.discard(c)
+            reasons[c].append("weather:humid(window)")
+
+    # 3) 오늘 술 의향
+    if not trigger.drink_intent and "bar" in allowed:
+        allowed.discard("bar")
+        reasons["bar"].append("drink_intent:false")
+
+    excluded = {c: rs for c, rs in reasons.items() if rs}
+
+    return {
+        "allowed_categories": sorted(allowed),
+        "excluded_categories": excluded,
+        "hardfilter_debug": {
+            "window_utc": [start_utc.isoformat(), end_utc.isoformat()],
+            "forecast_samples": summary.samples,
+            "max_temp": summary.max_temp,
+            "min_temp": summary.min_temp,
+            "max_humidity": summary.max_humidity,
+            "raining_any": summary.raining_any,
+            "hot_any": summary.hot_any,
+            "cold_any": summary.cold_any,
+            "humid_any": summary.humid_any,
+            "time_window": trigger.time_window,
+            "drink_intent": trigger.drink_intent,
+            "thresholds": {
+                "TEMP_HOT_C": TEMP_HOT_C,
+                "TEMP_COLD_C": TEMP_COLD_C,
+                "HUMIDITY_HIGH": HUMIDITY_HIGH,
+            },
+        },
+    }
+
+# ---------- LangGraph 노드 어댑터 (state ↔ 함수 연결) ----------
+async def node_category_hard_filter(
+    state: dict,
+    weather_provider: Optional[ForecastProvider] = None
+) -> dict:
+    provider = weather_provider or Free3hForecastProvider()
+    result = await run_category_hard_filter(trigger=state["trigger"], weather_provider=provider)
+    return {**state, **result}

--- a/src/app/nodes/hardfilter_node.py
+++ b/src/app/nodes/hardfilter_node.py
@@ -1,0 +1,13 @@
+# src/app/nodes/hardfilter_node.py
+from __future__ import annotations
+from typing import Dict, Optional
+from app.models.schemas import Trigger
+from app.filters.hardfilter import run_category_hard_filter
+from app.weather.openweather import Free3hForecastProvider
+from app.weather.types import ForecastProvider
+
+async def node_category_hard_filter(state: Dict, provider: Optional[ForecastProvider] = None) -> Dict:
+    trig: Trigger = state["trigger"]
+    p = provider or Free3hForecastProvider()
+    result = await run_category_hard_filter(trigger=trig, weather_provider=p)
+    return {**state, **result}

--- a/src/app/utils/timewindow.py
+++ b/src/app/utils/timewindow.py
@@ -1,0 +1,21 @@
+# src/app/utils/timewindow.py
+from __future__ import annotations
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+def parse_hm(hm: str) -> tuple[int, int]:
+    h, m = hm.split(":")
+    return int(h), int(m)
+
+def window_now_to_end_local_strict(end_hm: str, *, tz: str) -> tuple[datetime, datetime]:
+    """로컬TZ 기준: 시작=지금(now), 종료=end_hm; 종료가 과거면 예외."""
+    now_local = datetime.now(ZoneInfo(tz))
+    h, m = parse_hm(end_hm)
+    end_local = now_local.replace(hour=h, minute=m, second=0, microsecond=0)
+    if end_local <= now_local:
+        raise ValueError(f"end time must be later than now; now={now_local:%H:%M}, end={end_hm}")
+    return now_local.astimezone(ZoneInfo("UTC")), end_local.astimezone(ZoneInfo("UTC"))
+
+def slot_overlaps(slot_start_utc: datetime, slot_hours: int, start_utc: datetime, end_utc: datetime) -> bool:
+    slot_end = slot_start_utc + timedelta(hours=slot_hours)
+    return (slot_start_utc < end_utc) and (slot_end > start_utc)

--- a/src/app/weather/openweather.py
+++ b/src/app/weather/openweather.py
@@ -1,0 +1,54 @@
+# src/app/weather/openweather.py
+from __future__ import annotations
+from datetime import datetime
+from zoneinfo import ZoneInfo
+import httpx
+from typing import List, Dict, Any
+
+from app.core.settings import OPENWEATHER_API_KEY, TEMP_HOT_C, TEMP_COLD_C, HUMIDITY_HIGH
+from app.core.urls import ow_url
+from app.utils.timewindow import slot_overlaps
+from app.weather.types import ForecastProvider, WindowSummary
+
+class Free3hForecastProvider(ForecastProvider):
+    """
+    무료 5일/3시간 예보 사용. URL은 core.urls 모듈에서 주입.
+    """
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or OPENWEATHER_API_KEY
+        if not self.api_key:
+            raise RuntimeError("OPENWEATHER_API_KEY missing")
+
+    async def _get(self, *, lat: float, lon: float) -> List[Dict[str, Any]]:
+        url = ow_url("forecast3h", pro=False)  # ← 하드코드 제거
+        params = {"lat": lat, "lon": lon, "appid": self.api_key, "units": "metric"}
+        async with httpx.AsyncClient(timeout=7.0) as client:
+            r = await client.get(url, params=params)
+            r.raise_for_status()
+        return r.json().get("list", [])
+
+    async def window_summary(self, *, lat: float, lon: float, start_dt: datetime, end_dt: datetime) -> WindowSummary:
+        slots = await self._get(lat=lat, lon=lon)
+        sel = []
+        for it in slots:
+            slot_start = datetime.utcfromtimestamp(int(it["dt"])).replace(tzinfo=ZoneInfo("UTC"))
+            if slot_overlaps(slot_start, 3, start_dt, end_dt):
+                sel.append(it)
+
+        if not sel:
+            return WindowSummary(False, False, False, False, 0, None, None, None, raw_slots=[])
+
+        temps = [float(x["main"]["temp"]) for x in sel]
+        hums  = [int(x["main"]["humidity"]) for x in sel]
+        conds = [((x.get("weather") or [{}])[0].get("main","")).lower() for x in sel]
+
+        raining = any(("rain" in c) or ("drizzle" in c) for c in conds)
+        hot     = any(t >= TEMP_HOT_C for t in temps)
+        cold    = any(t <= TEMP_COLD_C for t in temps)
+        humid   = any(h >= HUMIDITY_HIGH for h in hums)
+
+        return WindowSummary(
+            raining_any=raining, hot_any=hot, cold_any=cold, humid_any=humid,
+            samples=len(sel), max_temp=max(temps), min_temp=min(temps), max_humidity=max(hums),
+            raw_slots=sel,
+        )

--- a/src/app/weather/types.py
+++ b/src/app/weather/types.py
@@ -1,0 +1,20 @@
+# src/app/weather/types.py
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol, List, Dict, Any
+
+@dataclass
+class WindowSummary:
+    raining_any: bool
+    hot_any: bool
+    cold_any: bool
+    humid_any: bool
+    samples: int
+    max_temp: float | None
+    min_temp: float | None
+    max_humidity: int | None
+    raw_slots: List[Dict[str, Any]] | None = None
+
+class ForecastProvider(Protocol):
+    async def window_summary(self, *, lat: float, lon: float, start_dt: datetime, end_dt: datetime) -> WindowSummary: ...


### PR DESCRIPTION
## 📝 목적/배경
- 데이트 코스 추천 파이프라인에서 하드 필터 단계 필요
- 프론트가 보낸 trigger 데이터(time_window, drink_intent, start[lng,lat])와 날씨 예보(무료 3시간 간격)를 결합해, 확실히 배제해야 할 카테고리를 선제적으로 제거하여 LLM 탐색 범위를 줄이고 추천 품질/비용을 개선합니다.

## 🔧 주요 변경 요약
- [ ] 하드필터가 트리거(now→end, drink_intent, 위치) + 날씨 예보기반으로 동작하도록 구현
- [ ] openweatherapi로 날씨 예보정보 3시간 단위로 조회가능
- [ ] 필터 규칙: time_window 구간 내 비/덥/춥/고습 중 하나라도 true → `walk`, `nature` 제외; `drink_intent=false` → `bar` 제외

## 🎥 스크린샷/데모 

## 🔗 이슈 연결
- PIT-108

## ✅ 체크리스트
- [ ] merge branch 가 **develop** 인지 확인
- [ ] 모든 코드가 정상 동작하는지 확인
- [ ] 누구나 이해할 수 있도록 변경 사항이 충분히 설명되어 있는지 확인

## 📌 기타.
- `.env`로 임계값 조정: `WEATHER_TZ`, `RECO_TEMP_HOT_C`, `RECO_TEMP_COLD_C`, `RECO_HUMIDITY_HIGH`.
