### PR TITLE
[FEAT] implement sequence_agent - pit 109

### DIFF
--- a/src/app/nodes/sequence_llm_node.py
+++ b/src/app/nodes/sequence_llm_node.py
@@ -1,0 +1,88 @@
+# sequence_llm_node.py
+import json
+from typing import Dict, Any, List
+from langsmith import Client
+import re
+from app.models.schemas import State
+from ..tests.test_data import initial_state 
+
+# config와 llm 임포트
+from config import llm
+
+# LangSmith 클라이언트 초기화
+try:
+    client = Client()
+except Exception as e:
+    print(f"⚠️ LangSmith Client 초기화 실패. 오류: {e}")
+    client = None
+
+def sequence_llm_node(state: State) -> Dict[str, Any]:
+    # ... (기존과 동일한 코드) ...
+    print("✅ 카테고리 시퀀스 LLM 노드 실행")
+    if not client:
+        print("⛔️ LangSmith 클라이언트가 없어 노드를 건너뜁니다.")
+        return {"recommended_sequence": [], "status": "failed"}
+
+    input_data = {
+        "var2": json.dumps(state["available_categories"], ensure_ascii=False, indent=2),
+        "user1": json.dumps(state["user_data"], ensure_ascii=False, indent=2),
+        "user2": "{}",   # 테스트 단계에서는 비워두거나 다른 dummy 데이터 넣기
+        "couple": "{}",  # 마찬가지
+        "trigger": json.dumps(state["trigger_data"], ensure_ascii=False, indent=2),
+        "question": state["query"],
+    }  
+    try:
+        prompt_template = client.pull_prompt("gh_sequence")
+        formatted_messages = prompt_template.format_prompt(**input_data).to_messages()
+        llm_raw_result = llm.invoke(formatted_messages)
+
+        response_text = ""
+        if hasattr(llm_raw_result, "content"):
+            response_text = llm_raw_result.content.strip()
+        else:
+            response_text = str(llm_raw_result).strip()
+        
+       # ```json ... ``` 제거
+        if response_text.startswith("```"):
+            response_text = response_text.strip("`").strip()
+            if response_text.lower().startswith("json"):
+                response_text = response_text[4:].strip()
+
+        # 대괄호 블록만 추출
+        match = re.search(r"\[.*\]", response_text, re.S)
+        if match:
+            response_text = match.group()
+
+        try:
+            recommended_sequence: List[str] = json.loads(response_text)
+            if not isinstance(recommended_sequence, list):
+                recommended_sequence = []
+                print(f"⚠️ LLM 응답이 예상한 리스트 형식이 아닙니다: {response_text}")
+        except json.JSONDecodeError:
+            recommended_sequence = []
+            print(f"⚠️ LLM 응답 JSON 파싱 실패: {response_text}")
+
+        state["recommended_sequence"] = recommended_sequence
+        print(f"✔️ 추천 카테고리 시퀀스: {state['recommended_sequence']}")
+
+        return {"recommended_sequence": state['recommended_sequence']}
+
+    except Exception as e:
+        print(f"⛔️ LLM 호출 또는 프롬프트 처리 중 오류 발생: {e}")
+        state["recommended_sequence"] = []
+        return {"recommended_sequence": state['recommended_sequence'], "status": "failed"}
+    
+# 파일 맨 아래에 추가
+if __name__ == "__main__":
+    from ..tests.test_data import initial_state  # <-- 이 부분도 수정되었습니다.
+    import asyncio
+
+    print("--- sequence_llm_node 테스트 시작 ---")
+    
+    async def test_node():
+        result = sequence_llm_node(initial_state)
+        print("\n--- 테스트 결과 ---")
+        print(f"반환 값: {result}")
+        print(f"업데이트된 상태: {initial_state}")
+        
+    asyncio.run(test_node())


### PR DESCRIPTION
## 📝 목적/배경
- 사용자 입력과 trigger 데이터를 기반으로 추천 카테고리 시퀀스를 생성하는 LLM 노드 필요
- LLM 응답이 항상 JSON 배열 형식이 아니어서 파싱 안정성을 높일 필요가 있음
- 파이프라인 테스트 실행을 위해 `__main__` 테스트 코드 추가

## 🔧 주요 작업(변경) 사항
- [x] `sequence_llm_node` 구현
  - LangSmith prompt(`gh_sequence`) 호출 및 LLM 응답 처리
  - 응답 전처리(````json ... ````, 대괄호 블록 추출 등) 추가
  - JSONDecodeError 방어 코드 추가
- [x] LangSmith 클라이언트 예외 처리 (클라이언트 없음 → 실패 처리)
- [x] 테스트 실행용 `__main__` 블록 추가 (로컬에서 단독 실행 가능)

## 🎥 스크린샷/데모 (선택)
<img width="908" height="215" alt="스크린샷 2025-09-24 오후 4 30 46" src="https://github.com/user-attachments/assets/08bab6e5-870c-44a1-a76e-0b0d8c2a2587" />

## 🔗 이슈 연결
- PIT-109

## ✅ 체크리스트
- [ ] merge branch 가 develop 인지 확인
- [ ] 모든 코드가 잘 작동하는지 확인
- [ ] 모두가 알아 볼 수 있도록 작성 되어 있는지

## 📌 기타
- 프롬프트 명칭(`gh_sequence`)은 LangSmith 프로젝트 내에서 관리 예정
- 추후 테스트 데이터 확장 및 통합 테스트 케이스 작성 필요