### PR TITLE
[FIX]: fix python running error  - PIT-298

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -27,7 +27,7 @@ FROM python:3.11-slim AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
-    PYTHONPATH=/app
+    PYTHONPATH=/app/src
 
 WORKDIR /app
 
@@ -39,4 +39,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "src.app.server:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.server:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## 📝 목적/배경
- fix error(`Module Not Found Error`) by modifying PYTHONPATH when running the FastAPI Server

## 🔧 주요 작업(변경) 사항
- [ ] 

## 🎥 스크린샷/데모 (선택)
<이미지 또는 gif>

## 🔗 이슈 연결
- PID-298

## ✅ 체크리스트
- [ ] merge branch 가 develop 인지 확인
- [ ] 모든 코드가 잘 작동하는지 확인
- [ ] 모두가 알아 볼 수 있도록 작성 되어 있는지

## 📌 기타